### PR TITLE
GH #846 Attach media button in comment not working in Safari in IOS mobile devices

### DIFF
--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -1921,7 +1921,32 @@ function renderUploadercomment_media( widget_id, parent_id_type ) {
 
         commentObj[widget_id].initUploader(false);
 
+		/*
+		 * Fix for file selector does not open in Safari browser in IOS.
+		 * In Safari in IOS, Plupload don't click on it's input(type=file), so file selector dialog won't open.
+		 * In order to fix this, when rtMedia's attach media button is clicked,
+		 * we check if Plupload's input(type=file) is clicked or not, if it's not clicked, then we click it manually
+		 * to open file selector.
+		 */
 
+		// Initially, select file dialog is close.
+		var file_dialog_open = false;
+
+		// Plupload will click on this input when user click on rtMedia's attach media button.
+		var input_file_el = '#' + plupload_comment.container + ' input[type=file]:first';
+
+		// Bind callback on Plupload's input element.
+		jQuery( document.body ).on( 'click', input_file_el, function() {
+			file_dialog_open = true;
+		} );
+
+		// Bind callback on rtMedia's attach media button.
+		jQuery( document.body ).on( 'click', '#' + button, function() {
+			if ( false === file_dialog_open ) {
+				jQuery( input_file_el ).click();
+				file_dialog_open = false;
+			}
+		} );
 
 		var form_html = jQuery( "."+comment_media_wrapper+widget_id );
 		if( jQuery( form_html ).find('div.rtmedia-plupload-container').length ){


### PR DESCRIPTION
The problem is in Plupload library, plupload's input button with attribute type equals to file which is responsible for file selector to open is not clicked by plupload in safari in IOS mobile devices. So, by clicking it manually, file selector can be opened.