### PR TITLE
Develop

### DIFF
--- a/bin/.travis.yml
+++ b/bin/.travis.yml
@@ -24,6 +24,7 @@ before_script:
   - sudo apt-get -qq purge mysql* graphviz* && sudo apt-get -qq autoremove
   - sudo bash -c 'echo -e "[user]\n\tname = abc\n\temail = root@localhost.com" > /home/travis/.gitconfig'
   - wget -qO ee rt.cx/ee && sudo bash ee
+  - sudo ee stack install
   - sudo wp --allow-root cli update --nightly
   - sudo apt-get update
   - sudo tail /var/log/ee/ee.log

--- a/bin/.travis.yml
+++ b/bin/.travis.yml
@@ -15,10 +15,10 @@ addons:
   browserstack:
     username: rtcamp3
     access_key:
-       secure: VFBgrctr5uDgE4PIea7QoXJDdQqq5TjPhvEcEBBcymbsP7cYUniD8K/0At+hArw5fqKajNlPZZjbxEhBRVv4hXNin++S6qwLeHCQMyHWQTt5vOULL16R2GsO30QUkFT/Egw2rh9v6qBei7Ol2mwz7i+XzZQE8cSDa/TJl7wMVwU=
+       secure: j7XE5uUiMYLvM1GeLYzC28IF+v9XPW5n1+dhtK9had4BWlTdkJEjcUeE8czkNQZB6fY//mB5mRMsZrmofF6fB5D/5QNzcK5hmIj1kL/UVTl+9KpTmpRHJMESx2hQM4ORwv2ir/kXSE1x8NqvFrjEebdaOTqAMiG0fRIuluX/NYa/d741l7WkA2EULDcHNDQfLOVzwByBdiij8CgnAI0lGri/TErvVZjcTarJmsx67U7wYurMi5cWQvYd6MRLDNhbST8nqFCH5wvx7Dl/extbgVk5pPw94eRmyEIGT+BqeGjZSwv9GP2HkQ1irDHCiWEhk56PsRT7skaMs00EMbJjyV4we0+ilsj5y1t5AOc8gPjJqE0DFH889Bw50MjhQ6EeDdbpv0kSwZ+2uRZ2rOYGY0nWOu2hlhBosBzEGhQMJWDhzCDbgie1Wbz/QBgaxZ12aGSOC4A6TVWL9J6f2TVza7Aij6X/LMM5bjVVkI8cRolo6wRKOkBc/WsYg5nngsuVR61Aod2dc7pUWNICwG/ou1y0uTvSN6bEt7aRpGTY/SRO0+yW5btw45U5NZ9LAMKdpOpteUbcu6UbAeRNbaxVGpasr8m9uacbTvGehFYJSFqm06d/elE5eveT4vcp7qp4onjdqc4kmAlNZ5R2vNANkuretUJCpEMb9xRQ3h2U6v8=
 
 before_script:
-  ## PHP_CodeSniffer
+
   - export PLUGIN_DIR=$(pwd)
   - sudo rm -rf /etc/mysql/
   - sudo apt-get -qq purge mysql* graphviz* && sudo apt-get -qq autoremove
@@ -26,6 +26,7 @@ before_script:
   - wget -qO ee rt.cx/ee && sudo bash ee
   - sudo apt-get update
   - sudo tail /var/log/ee/ee.log
+  - sudo wp --allow-root cli update --nightly
   - sudo ee site create automation.rtmedia.me --wp --user=ADMINUSER --email=sumeet.sarna@rtcamp.com --pass=ADMINPASS
   - sudo sed -i '/^127.0.0.1/ s/$/ automation.rtmedia.me/' /etc/hosts
   - sudo chmod 777 -R /var/www

--- a/bin/.travis.yml
+++ b/bin/.travis.yml
@@ -23,10 +23,10 @@ before_script:
   - sudo rm -rf /etc/mysql/
   - sudo apt-get -qq purge mysql* graphviz* && sudo apt-get -qq autoremove
   - sudo bash -c 'echo -e "[user]\n\tname = abc\n\temail = root@localhost.com" > /home/travis/.gitconfig'
+  - sudo wp --allow-root cli update --nightly
   - wget -qO ee rt.cx/ee && sudo bash ee
   - sudo apt-get update
   - sudo tail /var/log/ee/ee.log
-  - sudo wp --allow-root cli update --nightly
   - sudo ee site create automation.rtmedia.me --wp --user=ADMINUSER --email=sumeet.sarna@rtcamp.com --pass=ADMINPASS
   - sudo sed -i '/^127.0.0.1/ s/$/ automation.rtmedia.me/' /etc/hosts
   - sudo chmod 777 -R /var/www

--- a/bin/.travis.yml
+++ b/bin/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - sudo bash -c 'echo -e "[user]\n\tname = abc\n\temail = root@localhost.com" > /home/travis/.gitconfig'
   - wget -qO ee rt.cx/ee && sudo bash ee
   - sudo ee stack install
-  - sudo wp --allow-root cli update --nightly -y
+  - sudo wp --yes --allow-root cli update --nightly
   - sudo apt-get update
   - sudo tail /var/log/ee/ee.log
   - sudo ee site create automation.rtmedia.me --wp --user=ADMINUSER --email=sumeet.sarna@rtcamp.com --pass=ADMINPASS

--- a/bin/.travis.yml
+++ b/bin/.travis.yml
@@ -15,7 +15,7 @@ addons:
   browserstack:
     username: rtcamp3
     access_key:
-       secure: j7XE5uUiMYLvM1GeLYzC28IF+v9XPW5n1+dhtK9had4BWlTdkJEjcUeE8czkNQZB6fY//mB5mRMsZrmofF6fB5D/5QNzcK5hmIj1kL/UVTl+9KpTmpRHJMESx2hQM4ORwv2ir/kXSE1x8NqvFrjEebdaOTqAMiG0fRIuluX/NYa/d741l7WkA2EULDcHNDQfLOVzwByBdiij8CgnAI0lGri/TErvVZjcTarJmsx67U7wYurMi5cWQvYd6MRLDNhbST8nqFCH5wvx7Dl/extbgVk5pPw94eRmyEIGT+BqeGjZSwv9GP2HkQ1irDHCiWEhk56PsRT7skaMs00EMbJjyV4we0+ilsj5y1t5AOc8gPjJqE0DFH889Bw50MjhQ6EeDdbpv0kSwZ+2uRZ2rOYGY0nWOu2hlhBosBzEGhQMJWDhzCDbgie1Wbz/QBgaxZ12aGSOC4A6TVWL9J6f2TVza7Aij6X/LMM5bjVVkI8cRolo6wRKOkBc/WsYg5nngsuVR61Aod2dc7pUWNICwG/ou1y0uTvSN6bEt7aRpGTY/SRO0+yW5btw45U5NZ9LAMKdpOpteUbcu6UbAeRNbaxVGpasr8m9uacbTvGehFYJSFqm06d/elE5eveT4vcp7qp4onjdqc4kmAlNZ5R2vNANkuretUJCpEMb9xRQ3h2U6v8=
+       secure: VFBgrctr5uDgE4PIea7QoXJDdQqq5TjPhvEcEBBcymbsP7cYUniD8K/0At+hArw5fqKajNlPZZjbxEhBRVv4hXNin++S6qwLeHCQMyHWQTt5vOULL16R2GsO30QUkFT/Egw2rh9v6qBei7Ol2mwz7i+XzZQE8cSDa/TJl7wMVwU=
 
 before_script:
 
@@ -46,7 +46,7 @@ before_script:
   - nohup ./BrowserStackLocal --key $BROWSERSTACK_ACCESS_KEY &
   - cd $PLUGIN_DIR/tests/codeception/
   - composer update
-  - export PATH="$PATH:/home/travis/build/sumeetsarna/rtMedia/tests/codeception/vendor/bin"
+  - export PATH="$PATH:/home/travis/build/rtMediaWP/rtMedia/tests/codeception/vendor/bin"
     ## PHP_CodeSniffer
   - pear install pear/PHP_CodeSniffer-2.9.1
   - git clone git://github.com/wimg/PHPCompatibility.git $(pear config-get php_dir)/PHP/CodeSniffer/Standards/PHPCompatibility

--- a/bin/.travis.yml
+++ b/bin/.travis.yml
@@ -23,8 +23,8 @@ before_script:
   - sudo rm -rf /etc/mysql/
   - sudo apt-get -qq purge mysql* graphviz* && sudo apt-get -qq autoremove
   - sudo bash -c 'echo -e "[user]\n\tname = abc\n\temail = root@localhost.com" > /home/travis/.gitconfig'
-  - sudo wp --allow-root cli update --nightly
   - wget -qO ee rt.cx/ee && sudo bash ee
+  - sudo wp --allow-root cli update --nightly
   - sudo apt-get update
   - sudo tail /var/log/ee/ee.log
   - sudo ee site create automation.rtmedia.me --wp --user=ADMINUSER --email=sumeet.sarna@rtcamp.com --pass=ADMINPASS
@@ -45,7 +45,7 @@ before_script:
   - nohup ./BrowserStackLocal --key $BROWSERSTACK_ACCESS_KEY &
   - cd $PLUGIN_DIR/tests/codeception/
   - composer update
-  - export PATH="$PATH:/home/travis/build/rtMediaWP/rtMedia/tests/codeception/vendor/bin"
+  - export PATH="$PATH:/home/travis/build/sumeetsarna/rtMedia/tests/codeception/vendor/bin"
     ## PHP_CodeSniffer
   - pear install pear/PHP_CodeSniffer-2.9.1
   - git clone git://github.com/wimg/PHPCompatibility.git $(pear config-get php_dir)/PHP/CodeSniffer/Standards/PHPCompatibility

--- a/bin/.travis.yml
+++ b/bin/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - sudo apt-get -qq purge mysql* graphviz* && sudo apt-get -qq autoremove
   - sudo bash -c 'echo -e "[user]\n\tname = abc\n\temail = root@localhost.com" > /home/travis/.gitconfig'
   - wget -qO ee rt.cx/ee && sudo bash ee
-  - sudo ee stack install
+  - sudo ee stack install --wpcli
   - sudo wp --yes --allow-root cli update --nightly
   - sudo apt-get update
   - sudo tail /var/log/ee/ee.log
@@ -35,7 +35,7 @@ before_script:
   - cd $PLUGIN_DIR
   - cp -Rf * /var/www/automation.rtmedia.me/htdocs/wp-content/plugins/rtMedia/
   - cd /var/www/automation.rtmedia.me/htdocs/
-  - wp --allow-root plugin install https://downloads.wordpress.org/plugin/buddypress.2.8.2.zip
+  - wp --allow-root plugin install https://downloads.wordpress.org/plugin/buddypress.2.9.1.zip
   - wp plugin activate --all
   - cd $PLUGIN_DIR
   - cd tests/codeception/tests/_data

--- a/bin/.travis.yml
+++ b/bin/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - sudo bash -c 'echo -e "[user]\n\tname = abc\n\temail = root@localhost.com" > /home/travis/.gitconfig'
   - wget -qO ee rt.cx/ee && sudo bash ee
   - sudo ee stack install
-  - sudo wp --allow-root cli update --nightly
+  - sudo wp --allow-root cli update --nightly -y
   - sudo apt-get update
   - sudo tail /var/log/ee/ee.log
   - sudo ee site create automation.rtmedia.me --wp --user=ADMINUSER --email=sumeet.sarna@rtcamp.com --pass=ADMINPASS

--- a/bin/.travis.yml
+++ b/bin/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - sudo apt-get -qq purge mysql* graphviz* && sudo apt-get -qq autoremove
   - sudo bash -c 'echo -e "[user]\n\tname = abc\n\temail = root@localhost.com" > /home/travis/.gitconfig'
   - wget -qO ee rt.cx/ee && sudo bash ee
-  - sudo ee stack install --wpcli
+  - sudo ee stack install
   - sudo wp --yes --allow-root cli update --nightly
   - sudo apt-get update
   - sudo tail /var/log/ee/ee.log


### PR DESCRIPTION
Update Travis file to fix WP CLI error

Update to use latest BuddyPress plugin.

Followed workaround mentioned here https://easyengine.io/blog/solution-couldnt-extract-wordpress-archive-error/
