### PR TITLE
Update attribute to display video properly on single media view

### DIFF
--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -552,8 +552,9 @@ function rtmedia_media( $size_flag = true, $echo = true, $media_size = 'rt_media
 			$size   = ' width="' . esc_attr( $rtmedia->options['defaultSizes_video_singlePlayer_width'] ) . '" height="' . esc_attr( $height ) . '%" ';
 			$html   = "<div id='rtm-mejs-video-container' style='width:" . esc_attr( $rtmedia->options['defaultSizes_video_singlePlayer_width'] ) . 'px;height:' . esc_attr( $height ) . "%;  max-width:96%;max-height:80%;'>";
 			if ( empty( $youtube_url ) ) {
-				$html_video = '<video poster="" src="%s" %s type="video/mp4" class="wp-video-shortcode" id="rt_media_video_%s" controls="controls" preload="none"></video>';
-				$html .= sprintf( $html_video, esc_url( wp_get_attachment_url( $rtmedia_media->media_id ) ), esc_attr( $size ), esc_attr( $rtmedia_media->id ) );
+				// added poster for showing thumbnail and changed preload value to fix rtMedia GL-209.
+				$html_video = '<video poster="%s" src="%s" %s type="video/mp4" class="wp-video-shortcode" id="rt_media_video_%s" controls="controls" preload="metadata"></video>';
+				$html      .= sprintf( $html_video, esc_url( $rtmedia_media->cover_art ), esc_url( wp_get_attachment_url( $rtmedia_media->media_id ) ), esc_attr( $size ), esc_attr( $rtmedia_media->id ) );
 			} else {
 				$html_video = '<video width="640" height="360" class="url-video" id="video-id-%s" preload="none"><source type="video/youtube" src="%s" /></video>';
 				$html .= sprintf( $html_video, esc_attr( $rtmedia_media->id ), esc_url( wp_get_attachment_url( $rtmedia_media->media_id ) ) );


### PR DESCRIPTION
ref `rtMedia GL-209`

fix issue with video height and thumbnail in single media view.