### PR TITLE
Removed space between headings in rtMedia privacy data

### DIFF
--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1538,13 +1538,12 @@ function rtm_plugin_privacy_information() {
 		ob_start();
 		?>
 		<p>We collect your information during the checkout process on your purchase. The information collected from you may include, but is not limited to, your name, billing address, shipping address, email address, phone number, credit card/payment details and any other details that might be requested from you for the purpose of processing.</p>
-		<br/>
-		<p><b>Handling this data will also allow us to:</b></br>
-		- Send you important service information.<br/>
+		<h2>Handling this data will also allow us to:</h2>
+		<p>- Send you important service information.<br/>
 		- Respond to your queries or complaints.<br/>
-		- Set up and administer your account, provide technical and/or customer support, and to verify your identity.</p><br/>
-		<p><b>Additionally we may also collect the following information:</b><br/>
-		- Your comments and product reviews if you choose to leave them on our website.
+		- Set up and administer your account, provide technical and/or customer support, and to verify your identity.</p>
+		<h2>Additionally we may also collect the following information:</h2>
+		<p>- Your comments and product reviews if you choose to leave them on our website.
 		- Account email/password to allow you to access your account, if you have one.
 		- If you choose to create an account with us, your name, address, and email address, which will be used to populate the checkout for future orders.</p>
 		<?php


### PR DESCRIPTION
Removed space between headings in rtMedia privacy data which was shown by us at back end of WordPress