### PR TITLE
Remove BP nouveau patch

### DIFF
--- a/app/helper/RTMediaModel.php
+++ b/app/helper/RTMediaModel.php
@@ -107,14 +107,9 @@ class RTMediaModel extends RTDBModel {
 			$qorder_by = '';
 		}
 
-		$select      = apply_filters( 'rtmedia-model-select-query', $select, $this->table_name );
-		$bp_template = get_option( '_bp_theme_package_id' );
-
-		if ( empty( $bp_template ) && 'nouveau' !== $bp_template && "likes" === $rtmedia_interaction->routes['media']->query_vars[0] ) {
-			$join  = apply_filters( 'rtmedia-model-join-query', $join, $this->table_name );
-			$where = apply_filters( 'rtmedia-model-where-query', $where, $this->table_name , $join);
-		}
-
+		$select    = apply_filters( 'rtmedia-model-select-query', $select, $this->table_name );
+		$join      = apply_filters( 'rtmedia-model-join-query', $join, $this->table_name );
+		$where     = apply_filters( 'rtmedia-model-where-query', $where, $this->table_name , $join);
 		$qgroup_by = apply_filters( 'rtmedia-model-group-by-query', $qgroup_by, $this->table_name );
 		$qorder_by = apply_filters( 'rtmedia-model-order-by-query', $qorder_by, $this->table_name );
 


### PR DESCRIPTION
if ( empty( $bp_template ) && 'nouveau' !== $bp_template && "likes" === $rtmedia_interaction->routes['media']->query_vars[0] ) {

This condition breaks the functionality of major add-ons.
So removed this patch from the core plugin.