### PR TITLE
Show post update button when media file is attached

### DIFF
--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -1803,6 +1803,7 @@ function rtmedia_selected_file_list( plupload, file, uploader, error, comment_me
 	rtmedia_plupload_file += '</li>';
 
 	jQuery( rtmedia_plupload_file ).appendTo( rtmedia_uploader_filelist );
+	jQuery( '#whats-new' ).focus();
 	var type = file.type;
 	var media_title = file.name;
 	var ext = media_title.substring( media_title.lastIndexOf( '.' ) + 1, media_title.length );


### PR DESCRIPTION
After uploading image we need to click on textarea to upload it. Upload button must be shown inside textarea near update post button.

Solved in this PR.

shown post update button on attaching media.

Cause: Nouveau template is generating Post Update button dynamically on click of textarea.

Solution: Focused on textarea after uploading media in Activity page. So Post Update button will be generated.