### PR TITLE
FIX 2 GL-131: Remove notice only on button click

### DIFF
--- a/app/admin/RTMediaAdmin.php
+++ b/app/admin/RTMediaAdmin.php
@@ -273,7 +273,7 @@ if ( ! class_exists( 'RTMediaAdmin' ) ) {
 			<script type="text/javascript">
 				jQuery( document ).ready( function () {
 
-					jQuery( document ).on( 'click', '.rtm-is-dismissible > button.notice-dismiss', function () {
+					jQuery( document ).on( 'click', '.rtm-is-dismissible button.notice-dismiss', function () {
 						var elem = jQuery( this );
 
 						var action = elem.attr( 'data-action' );

--- a/app/admin/RTMediaAdmin.php
+++ b/app/admin/RTMediaAdmin.php
@@ -273,7 +273,7 @@ if ( ! class_exists( 'RTMediaAdmin' ) ) {
 			<script type="text/javascript">
 				jQuery( document ).ready( function () {
 
-					jQuery( document ).on( 'click', '.rtm-is-dismissible', function () {
+					jQuery( document ).on( 'click', '.rtm-is-dismissible > button.notice-dismiss', function () {
 						var elem = jQuery( this );
 
 						var action = elem.attr( 'data-action' );


### PR DESCRIPTION
In previous fix, the notice was being dismissed on click of notice itself.
This PR fixes that and allows user to dismiss the notice on click of dismiss button (x).