### PR TITLE
Fix issue for enable/disable of likes tab

### DIFF
--- a/app/main/controllers/template/RTMediaNav.php
+++ b/app/main/controllers/template/RTMediaNav.php
@@ -258,7 +258,10 @@ class RTMediaNav {
 			if ( ! $rtmedia->options[ 'allowedTypes_' . $type['name'] . '_enabled' ] ) {
 				continue;
 			}
-
+			// Skip to add likes tab here on attribute allowedTypes_likes_enabled because likes tab come from rtmedia-like addons.
+			if ( ! $rtmedia->options['general_enable_user_likes'] && 'likes' === $type['name'] ) {
+				continue;
+			}
 			$selected = '';
 
 			if ( isset( $rtmedia_query->action_query->media_type ) && $type['name'] === $rtmedia_query->action_query->media_type ) {


### PR DESCRIPTION
Issue : Create likes tab automatically based on allowedType_likes_enable attribute but it should be create through addons.

Solution: Just skip the allowedType_likes_enable attribute to create like tab.