### PR TITLE
Remove extra span from media comment

### DIFF
--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -1689,7 +1689,11 @@ jQuery( document ).ready( function( $ ) {
 		$( this ).attr( 'disabled', 'disabled' );
 
 		// Sanitize comment content and escape html tags
-		comment_content_el.val( jQuery( '<span/>' ).text( jQuery.trim( comment_content_el.val() ) ).html() );
+		if( '' !== comment_content_el.val().replace(/\&nbsp;/g, '') ) {
+			comment_content_el.val( jQuery( '<span/>' ).text( jQuery.trim( comment_content_el.val() ) ).html() );
+		} else {
+			comment_content_el.val( '' );
+		}
 
 		$.ajax( {
 			url: comment_form_el.attr( 'action' ),

--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -1689,9 +1689,7 @@ jQuery( document ).ready( function( $ ) {
 		$( this ).attr( 'disabled', 'disabled' );
 
 		// Sanitize comment content and escape html tags
-		if ( '' !== comment_content_el.val().replace(/\&nbsp;/g, '' ) ) {
-			comment_content_el.val( jQuery( '<span/>' ).text( jQuery.trim( comment_content_el.val() ) ).html() );
-		} else {
+		if ( '' === comment_content_el.val().replace(/\&nbsp;/g, '' ) ) {
 			comment_content_el.val( '' );
 		}
 

--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -1689,7 +1689,7 @@ jQuery( document ).ready( function( $ ) {
 		$( this ).attr( 'disabled', 'disabled' );
 
 		// Sanitize comment content and escape html tags
-		if( '' !== comment_content_el.val().replace(/\&nbsp;/g, '') ) {
+		if ( '' !== comment_content_el.val().replace(/\&nbsp;/g, '' ) ) {
 			comment_content_el.val( jQuery( '<span/>' ).text( jQuery.trim( comment_content_el.val() ) ).html() );
 		} else {
 			comment_content_el.val( '' );


### PR DESCRIPTION
Issue ref:- https://github.com/rtMediaWP/rtMedia/issues/1288

Issue: When we upload a media without comment a text then empty span is added to the comment .

Solution:- Add logical condition to check for comment text is empty or not and then stored data via ajax call.