### PR TITLE
Remove empty span from activity post

### DIFF
--- a/app/main/controllers/activity/RTMediaActivity.php
+++ b/app/main/controllers/activity/RTMediaActivity.php
@@ -40,7 +40,7 @@ class RTMediaActivity {
 
 		$html .= '<div class="rtmedia-'.$type.'-container">';
 
-		if ( ! empty( $this->activity_text ) ) {
+		if ( ! empty( $this->activity_text ) && '&nbsp;' !== $this->activity_text ) {
 			$html .= '<div class="rtmedia-'.$type.'-text"><span>';
 			$html .= $this->activity_text;
 			$html .= '</span></div>';


### PR DESCRIPTION
Issue ref:- https://github.com/rtMediaWP/rtMedia/issues/1288

Issue :- Add span for post text when we post something from activity post without text. 

Solution :- Add logical condition to avoid  span to add when text is empty.