### PR TITLE
[GH-367] Fix multiple media upload from activity for non-admin users

### DIFF
--- a/app/main/controllers/activity/RTMediaActivity.php
+++ b/app/main/controllers/activity/RTMediaActivity.php
@@ -169,6 +169,20 @@ class RTMediaActivity {
 		$activity .= $activity_content;
 		$activity .= $activity_container_end;
 
+		// Bypass comment links limit.
+		add_filter(
+			'option_comment_max_links',
+			function ( $values ) {
+				$rtmedia_attached_files = filter_input( INPUT_POST, 'rtMedia_attached_files', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
+				// Check  if files available.
+				if ( is_array( $rtmedia_attached_files ) && ! empty( $rtmedia_attached_files[0] ) ) {
+					// One url of image and other for anchor tag.
+					$values = count( $rtmedia_attached_files ) * 2;
+				}
+				return $values;
+			}
+		);
+
 		return bp_activity_filter_kses( $activity );
 	}
 


### PR DESCRIPTION
Added filter to bypass the limit of links on activity by changing the option of `comment_max_links.`