### PR TITLE
Fix duplicate comment issue

### DIFF
--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -259,12 +259,6 @@ class RTMediaBuddyPressActivity {
 	 */
 	public function bp_activity_content_before_save( $content ) {
 
-		// Fix duplication issue of comment media on activity by returning contents when activity type is comment.
-		$rtmedia_comment = filter_input( INPUT_POST, 'comment', FILTER_SANITIZE_STRING );
-		if ( ! empty( $rtmedia_comment ) ) {
-			return $content;
-		}
-
 		$rtmedia_attached_files = filter_input( INPUT_POST, 'rtMedia_attached_files', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
 		if ( ( ! empty( $rtmedia_attached_files ) ) && is_array( $rtmedia_attached_files ) ) {
 			$obj_activity = new RTMediaActivity( $rtmedia_attached_files, 0, $content );
@@ -872,6 +866,7 @@ class RTMediaBuddyPressActivity {
 					}
 
 					// create BuddyPress activity
+					remove_filter( 'bp_activity_content_before_save', array( $this, 'bp_activity_content_before_save' ) );
 					$activity_id = bp_activity_add( $activity_args );
 
 					/* save the profile activity id in the media meta */


### PR DESCRIPTION
Removed the bp_activity_content_before_save filter when creating comment activity, because the HTML for activity was already created on 837 which was creating duplication of the HTML content.