### PR TITLE
Fix single media activity upload issue for non-admin users

### DIFF
--- a/app/main/controllers/activity/RTMediaActivity.php
+++ b/app/main/controllers/activity/RTMediaActivity.php
@@ -177,7 +177,7 @@ class RTMediaActivity {
 				// Check  if files available.
 				if ( is_array( $rtmedia_attached_files ) && ! empty( $rtmedia_attached_files[0] ) ) {
 					// One url of image and other for anchor tag.
-					$values = count( $rtmedia_attached_files ) * 2;
+					$values = count( $rtmedia_attached_files ) * 3;
 				}
 				return $values;
 			}


### PR DESCRIPTION
Fix single media activity for non-admin users by limiting the link to 3 per media, as some of the media types has 3 links in markup. for Media Title link, image source and link on the image.