### PR TITLE
Fixed PHP warnings

### DIFF
--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1216,7 +1216,7 @@ class RTMedia {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_load_more_or_pagination', 'load_more' );
 		}
 
-		if ( isset( $rtmedia->options['buddypress_enableOnActivity'] ) ) {
+		if ( !empty( $rtmedia->options['buddypress_enableOnActivity'] ) ) {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_bp_enable_activity', (string) $rtmedia->options['buddypress_enableOnActivity'] );
 		} else {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_bp_enable_activity', '0' );

--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1210,13 +1210,13 @@ class RTMedia {
 			wp_localize_script( 'rtmedia-main', 'rtmedia_masonry_layout', 'false' );
 		}
 
-		if ( !empty( $rtmedia->options['general_display_media'] ) ) {
+		if ( ! empty( $rtmedia->options['general_display_media'] ) ) {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_load_more_or_pagination', (string) $rtmedia->options['general_display_media'] );
 		} else {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_load_more_or_pagination', 'load_more' );
 		}
 
-		if ( !empty( $rtmedia->options['buddypress_enableOnActivity'] ) ) {
+		if ( ! empty( $rtmedia->options['buddypress_enableOnActivity'] ) ) {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_bp_enable_activity', (string) $rtmedia->options['buddypress_enableOnActivity'] );
 		} else {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_bp_enable_activity', '0' );

--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1210,7 +1210,7 @@ class RTMedia {
 			wp_localize_script( 'rtmedia-main', 'rtmedia_masonry_layout', 'false' );
 		}
 
-		if ( isset( $rtmedia->options['general_display_media'] ) ) {
+		if ( !empty( $rtmedia->options['general_display_media'] ) ) {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_load_more_or_pagination', (string) $rtmedia->options['general_display_media'] );
 		} else {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_load_more_or_pagination', 'load_more' );


### PR DESCRIPTION
Fixed php warnings by avoiding the passing of an empty string as the 3rd argument to wp_localize_script. Also made sure to follow WordPress standards by adding a space after the "!" (which was there in my previous pull request).