### PR TITLE
Fix errors and warnings on rtmedia support page

### DIFF
--- a/app/helper/RTMediaSupport.php
+++ b/app/helper/RTMediaSupport.php
@@ -251,7 +251,7 @@ if ( ! class_exists( 'RTMediaSupport' ) ) {
 						if ( is_dir( $template_path . DIRECTORY_SEPARATOR . $value ) ) {
 							$sub_files = $this->rtmedia_scan_template_files( $template_path . DIRECTORY_SEPARATOR . $value );
 							foreach ( $sub_files as $sub_file ) {
-								$rt_to_dir_paths	= RTMediaTemplate::locate_template( substr( $sub_file, 0, ( count( $sub_file ) - 5 ) ) );
+								$rt_to_dir_paths	= RTMediaTemplate::locate_template( str_replace( '.php', '', $sub_file ) );
 								$rt_to_dir_path		= str_replace( '//', '/', $rt_to_dir_paths );
 								$result[]			= str_replace( ABSPATH . 'wp-content/', '', $rt_to_dir_path );
 							}


### PR DESCRIPTION
#1404 
Issue: Used `count` function on a string to remove the file extension ( .php )
Solution: Use str_replace to remove `.php` extention
