### PR TITLE
Fix GH-1535: Separated image and text using DOMDocument class

### DIFF
--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -96,6 +96,11 @@ class RTMediaBuddyPressActivity {
 		// So we need to iterate.
 		$div_list = $dom->getElementsByTagName( 'div' );
 
+		// Return if no divs found.
+		if ( empty( $div_list ) ) {
+			return $excerpt;
+		}
+
 		// We're storing first div to create final markup.
 		// If we create markup from dom object, it'll create whole HTML which we don't want.
 		$first_div = '';

--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -139,12 +139,12 @@ class RTMediaBuddyPressActivity {
 				if ( 'class' === $att->name && strpos( $att->value, 'rtmedia-activity-text' ) !== false ) {
 					// Create excerpt only on text and then set it to div text.
 					// We're using actual length / 2 to make space for image.
-					$custom_excerpt   = bp_create_excerpt( $div->textContent, (int) $excerpt_length / 2, array( 'ending' => '...' ) ); // phpcs:ignore
-					$div->textContent = trim( $custom_excerpt ); // phpcs:ignore
+					$custom_excerpt   = bp_create_excerpt( $div->textContent, (int) $excerpt_length / 2, array( 'ending' => '...' ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Can't change property name.
+					$div->textContent = trim( $custom_excerpt ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Can't change property name.
 
 					// Show 4 images if text is less, else show 2 images.
 					$images_to_show = 4;
-					if ( strlen( $div->textContent ) > 20 ) { // phpcs:ignore
+					if ( strlen( $div->textContent ) > 20 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Can't change property name.
 						$images_to_show = 2;
 					}
 
@@ -155,7 +155,7 @@ class RTMediaBuddyPressActivity {
 					$id = ( ! empty( $activities_template->activity->current_comment->id ) ? 'acomment-read-more-' . $activities_template->activity->current_comment->id : 'activity-read-more-' . $activity_id );
 
 					// Get final HTML.
-					$content = $first_div->ownerDocument->saveHTML( $first_div ); // phpcs:ignore
+					$content = $first_div->ownerDocument->saveHTML( $first_div ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Can't change property name.
 
 					// Append read more link and text.
 					$return = sprintf( '%1$s<span class="activity-read-more" id="%2$s"><a href="%3$s" rel="nofollow">%4$s</a></span>', $content, $id, bp_get_activity_thread_permalink(), $readmore );
@@ -199,14 +199,14 @@ class RTMediaBuddyPressActivity {
 				}
 
 				// Conditions to match required class.
-				if ( 'class' === $att->name && strpos( $att->value, 'rtm-activity-media-list' ) !== false && count( $ul->childNodes ) > 0 ) {
+				if ( 'class' === $att->name && strpos( $att->value, 'rtm-activity-media-list' ) !== false && count( $ul->childNodes ) > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Can't change property name.
 
 					// Number of li (images) allowed to show.
 					$count = 1;
 					// Array where items to remove will be stored.
 					$items_to_remove = array();
 					// Iterate all children of ul which are images (li).
-					foreach ( $ul->childNodes as $li ) { // phpcs:ignore
+					foreach ( $ul->childNodes as $li ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Can't change property name.
 
 						// If max number of images reached, add li to items_to_remove array.
 						if ( $count > $images_to_show ) {

--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -68,7 +68,7 @@ class RTMediaBuddyPressActivity {
 	}
 
 	/**
-	 * Show media even if the test is long with read more option.
+	 * Show media even if the text is long with read more option.
 	 *
 	 * @param string $excerpt  Excerpt of the activity text.
 	 * @param string $text     Actual text of activity.

--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -199,7 +199,7 @@ class RTMediaBuddyPressActivity {
 				}
 
 				// Conditions to match required class.
-				if ( 'class' === $att->name && strpos( $att->value, 'rtm-activity-media-list' ) !== false ) {
+				if ( 'class' === $att->name && strpos( $att->value, 'rtm-activity-media-list' ) !== false && count( $ul->childNodes ) > 0 ) {
 
 					// Number of li (images) allowed to show.
 					$count = 1;

--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -86,42 +86,52 @@ class RTMediaBuddyPressActivity {
 			return $excerpt;
 		}
 
+		// Get current activity id.
 		$activity_id = bp_get_activity_id();
 
+		// We need to separate text and rtMedia images, for this we need DOM manipulation.
 		$dom = new DOMDocument();
 		$dom->loadHTML( $text );
+		// We need to find div having rtmedia-activity-text class, but no direct method for it.
+		// So we need to iterate.
 		$div_list = $dom->getElementsByTagName( 'div' );
 
+		// We're storing first div to create final markup.
+		// If we create markup from dom object, it'll create whole HTML which we don't want.
 		$first_div = '';
 
-		$break = false;
 		foreach ( $div_list as $div ) {
+			// Set first div.
 			if ( empty( $first_div ) ) {
 				$first_div = $div;
 			}
 
-			if ( $break ) {
-				break;
-			}
-
+			// We need div with class attribute.
 			if ( empty( $div->attributes ) ) {
 				continue;
 			}
 
 			$atts = $div->attributes;
+			// Check attributes by iterating them.
 			foreach ( $atts as $att ) {
 				if ( empty( $att->name ) || empty( $att->value ) ) {
 					continue;
 				}
 
+				// Condition to find text div.
 				if ( 'class' === $att->name && 'rtmedia-activity-text' === $att->value ) {
+					// Create excerpt only on text and then set it to div text.
+					// We're using actual length / 2 to make space for image.
 					$custom_excerpt   = bp_create_excerpt( $div->textContent, (int) $excerpt_length / 2, array( 'ending' => '...' ) ); // phpcs:ignore
 					$div->textContent = trim( $custom_excerpt ); // phpcs:ignore
 
+					// Code copied from buddypress.
 					$id = ( ! empty( $activities_template->activity->current_comment->id ) ? 'acomment-read-more-' . $activities_template->activity->current_comment->id : 'activity-read-more-' . $activity_id );
 
+					// Get final HTML.
 					$content = $first_div->ownerDocument->saveHTML( $first_div ); // phpcs:ignore
 
+					// Append read more link and text.
 					$return = sprintf( '%1$s<span class="activity-read-more" id="%2$s"><a href="%3$s" rel="nofollow">%4$s</a></span>', $content, $id, bp_get_activity_thread_permalink(), $readmore );
 
 					return $return;

--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -119,7 +119,7 @@ class RTMediaBuddyPressActivity {
 				}
 
 				// Condition to find text div.
-				if ( 'class' === $att->name && 'rtmedia-activity-text' === $att->value ) {
+				if ( 'class' === $att->name && strpos( $att->value, 'rtmedia-activity-text' ) !== false ) {
 					// Create excerpt only on text and then set it to div text.
 					// We're using actual length / 2 to make space for image.
 					$custom_excerpt   = bp_create_excerpt( $div->textContent, (int) $excerpt_length / 2, array( 'ending' => '...' ) ); // phpcs:ignore


### PR DESCRIPTION
I used DOM manipulation class of php (DOMDocument) to separate image from text. I created custom excerpt where I only trimmed text and kept other HTML as it is.

Fixes #1535 