### PR TITLE
Fix GH-1535: loadHTML shows error for HTML5 entities, so disable errors

### DIFF
--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -103,7 +103,11 @@ class RTMediaBuddyPressActivity {
 
 		// We need to separate text and rtMedia images, for this we need DOM manipulation.
 		$dom = new DOMDocument();
+		// DOMDocument gives error on html5 tags, so we need to disable errors.
+		libxml_use_internal_errors( true );
 		$dom->loadHTML( $text );
+		// DOMDocument gives error on html5 tags, so we need to disable errors.
+		libxml_clear_errors();
 		// We need to find div having rtmedia-activity-text class, but no direct method for it.
 		// So we need to iterate.
 		$div_list = $dom->getElementsByTagName( 'div' );


### PR DESCRIPTION
Reference - https://stackoverflow.com/questions/6090667/php-domdocument-errors-warnings-on-html5-tags

Fixes: https://github.com/rtMediaWP/rtMedia/issues/1535#issuecomment-582234295