### PR TITLE
Fix GH-1567: Add utf-8 encoding in DOMDocument loadHTML method

### DIFF
--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -108,7 +108,8 @@ class RTMediaBuddyPressActivity {
 		$dom = new DOMDocument();
 		// DOMDocument gives error on html5 tags, so we need to disable errors.
 		libxml_use_internal_errors( true );
-		$dom->loadHTML( $text );
+		// Use utf-8 encoding for different languages.
+		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $text );
 		// DOMDocument gives error on html5 tags, so we need to disable errors.
 		libxml_clear_errors();
 		// We need to find div having rtmedia-activity-text class, but no direct method for it.


### PR DESCRIPTION
Prepend `<?xml encoding="utf-8" ?>` with activity text in loadHTML method of DOMDocument's class.
Fix #1567 