### PR TITLE
Moderation issue, i.e., media privacy changes after allowing moderated media from admin

### DIFF
--- a/app/main/controllers/media/RTMediaMeta.php
+++ b/app/main/controllers/media/RTMediaMeta.php
@@ -72,7 +72,7 @@ class RTMediaMeta {
 		if ( true === $duplicate ) {
 			$media_meta = $this->model->insert( array( 'media_id' => $id, 'meta_key' => $key, 'meta_value' => $value ) );
 		} else {
-			if ( $this->get_single_meta( $id, $key ) ) {
+			if ( false !== $this->get_single_meta( $id, $key ) ) {
 				$meta       = array( 'meta_value' => $value );
 				$where      = array( 'media_id' => $id, 'meta_key' => $key );
 				$media_meta = $this->model->update( $meta, $where );


### PR DESCRIPTION
This PR relates to the issue in the `Moderation` add-on. Link: https://github.com/rtCamp/rtmedia-moderation/issues/26

I've added the code check against `false` just for the reason when the saved privacy value is 0 and in the `if` condition, becomes false, that's why added strict type-checking.