### PR TITLE
Remove escaping from static strings

### DIFF
--- a/app/admin/RTMediaAdmin.php
+++ b/app/admin/RTMediaAdmin.php
@@ -939,8 +939,8 @@ if ( ! class_exists( 'RTMediaAdmin' ) ) {
 					)
 				);
 
-				wp_localize_script( 'rtmedia-admin', 'rtmedia_on_label', esc_html__( 'ON', 'buddypress-media' ) );
-				wp_localize_script( 'rtmedia-admin', 'rtmedia_off_label', esc_html__( 'OFF', 'buddypress-media' ) );
+				wp_localize_script( 'rtmedia-admin', 'rtmedia_on_label', __( 'ON', 'buddypress-media' ) );
+				wp_localize_script( 'rtmedia-admin', 'rtmedia_off_label', __( 'OFF', 'buddypress-media' ) );
 				wp_localize_script( 'rtmedia-admin', 'rtmedia_admin_ajax', $admin_ajax );
 				wp_localize_script( 'rtmedia-admin', 'rtmedia_admin_url', admin_url() );
 				/* path for file upload using ajax */

--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1319,39 +1319,39 @@ class RTMedia {
 		wp_localize_script( 'rtmedia-main', 'rtmedia_gallery_reload_on_upload', '1' );
 
 		// javascript messages.
-		wp_localize_script( 'rtmedia-magnific', 'rtmedia_load_more', esc_html__( 'Loading media', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_empty_activity_msg', esc_html__( 'Please enter some content to post.', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_empty_comment_msg', esc_html__( 'Empty comment is not allowed.', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_media_comment_delete_confirmation', esc_html__( 'Are you sure you want to delete this comment?', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_album_delete_confirmation', esc_html__( 'Are you sure you want to delete this Album?', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_drop_media_msg', esc_html__( 'Drop files here', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_album_created_msg', ' ' . esc_html__( 'album created successfully.', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_something_wrong_msg', esc_html__( 'Something went wrong. Please try again.', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_empty_album_name_msg', esc_html__( 'Enter an album name.', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_max_file_msg', esc_html__( 'Max file Size Limit : ', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_allowed_file_formats', esc_html__( 'Allowed File Formats', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_select_all_visible', esc_html__( 'Select All Visible', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_unselect_all_visible', esc_html__( 'Unselect All Visible', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_no_media_selected', esc_html__( 'Please select some media.', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_selected_media_delete_confirmation', esc_html__( 'Are you sure you want to delete the selected media?', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_selected_media_move_confirmation', esc_html__( 'Are you sure you want to move the selected media?', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_waiting_msg', esc_html__( 'Waiting', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_uploaded_msg', esc_html__( 'Uploaded', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_uploading_msg', esc_html__( 'Uploading', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_upload_failed_msg', esc_html__( 'Failed', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_close', esc_html__( 'Close', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_edit', esc_html__( 'Edit', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_delete', esc_html__( 'Delete', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_edit_media', esc_html__( 'Edit Media', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_remove_from_queue', esc_html__( 'Remove from queue', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_add_more_files_msg', esc_html__( 'Add more files', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_file_extension_error_msg', esc_html__( 'File not supported', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_more', esc_html__( 'more', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_less', esc_html__( 'less', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_read_more', esc_html__( 'Read more', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia__show_less', esc_html__( 'Show less', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-magnific', 'rtmedia_load_more', __( 'Loading media', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_empty_activity_msg', __( 'Please enter some content to post.', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_empty_comment_msg', __( 'Empty comment is not allowed.', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_media_comment_delete_confirmation', __( 'Are you sure you want to delete this comment?', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_album_delete_confirmation', __( 'Are you sure you want to delete this Album?', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_drop_media_msg', __( 'Drop files here', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_album_created_msg', ' ' . __( 'album created successfully.', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_something_wrong_msg', __( 'Something went wrong. Please try again.', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_empty_album_name_msg', __( 'Enter an album name.', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_max_file_msg', __( 'Max file Size Limit : ', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_allowed_file_formats', __( 'Allowed File Formats', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_select_all_visible', __( 'Select All Visible', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_unselect_all_visible', __( 'Unselect All Visible', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_no_media_selected', __( 'Please select some media.', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_selected_media_delete_confirmation', __( 'Are you sure you want to delete the selected media?', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_selected_media_move_confirmation', __( 'Are you sure you want to move the selected media?', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_waiting_msg', __( 'Waiting', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_uploaded_msg', __( 'Uploaded', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_uploading_msg', __( 'Uploading', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_upload_failed_msg', __( 'Failed', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_close', __( 'Close', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_edit', __( 'Edit', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_delete', __( 'Delete', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_edit_media', __( 'Edit Media', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_remove_from_queue', __( 'Remove from queue', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_add_more_files_msg', __( 'Add more files', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_file_extension_error_msg', __( 'File not supported', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_more', __( 'more', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_less', __( 'less', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_read_more', __( 'Read more', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia__show_less', __( 'Show less', 'buddypress-media' ) );
 		wp_localize_script( 'rtmedia-main', 'rtmedia_activity_text_with_attachment', apply_filters( 'rtmedia_required_activity_text_with_attachment', 'disable' ) );
-		wp_localize_script( 'rtmedia-main', 'rtmedia_delete_uploaded_media', esc_html__( 'This media is uploaded. Are you sure you want to delete this media?', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_delete_uploaded_media', __( 'This media is uploaded. Are you sure you want to delete this media?', 'buddypress-media' ) );
 		wp_localize_script( 'rtmedia-main', 'rtm_wp_version', get_bloginfo( 'version' ) );
 		wp_localize_script( 'rtmedia-backbone', 'rMedia_loading_media', RTMEDIA_URL . 'app/assets/admin/img/boxspinner.gif' );
 		$rtmedia_media_thumbs = array();
@@ -1367,8 +1367,8 @@ class RTMedia {
 		$rtmedia_media_thumbs = apply_filters( 'rtmedia_add_docs_thumbs', $rtmedia_media_thumbs );
 
 		wp_localize_script( 'rtmedia-backbone', 'rtmedia_media_thumbs', $rtmedia_media_thumbs );
-		wp_localize_script( 'rtmedia-backbone', 'rtmedia_set_featured_image_msg', esc_html__( 'Featured media set successfully.', 'buddypress-media' ) );
-		wp_localize_script( 'rtmedia-backbone', 'rtmedia_unset_featured_image_msg', esc_html__( 'Featured media removed successfully.', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-backbone', 'rtmedia_set_featured_image_msg', __( 'Featured media set successfully.', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-backbone', 'rtmedia_unset_featured_image_msg', __( 'Featured media removed successfully.', 'buddypress-media' ) );
 		wp_localize_script(
 			'rtmedia-backbone',
 			'rtmedia_edit_media_info_upload',
@@ -1377,7 +1377,7 @@ class RTMedia {
 				'description' => esc_html__( 'Description:', 'buddypress-media' ),
 			)
 		);
-		wp_localize_script( 'rtmedia-backbone', 'rtmedia_no_media_found', esc_html__( 'Oops !! There\'s no media found for the request !!', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-backbone', 'rtmedia_no_media_found', __( 'Oops !! There\'s no media found for the request !!', 'buddypress-media' ) );
 
 		// Localizing strings for rtMedia.backbone.js.
 		$rtmedia_backbone_strings = array(
@@ -1430,9 +1430,9 @@ class RTMedia {
 			wp_localize_script( 'rtmedia-backbone', 'rtmedia_bp_enable_activity', '0' );
 		}
 
-		wp_localize_script( 'rtmedia-backbone', 'rtmedia_upload_progress_error_message', esc_html__( 'There are some uploads in progress. Do you want to cancel them?', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-backbone', 'rtmedia_upload_progress_error_message', __( 'There are some uploads in progress. Do you want to cancel them?', 'buddypress-media' ) );
 		// Added to display error message when all media types upload are disabled.
-		wp_localize_script( 'rtmedia-backbone', 'rtmedia_media_disabled_error_message', esc_html__( 'Media upload is disabled. Please Enable at least one media type to proceed.', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-backbone', 'rtmedia_media_disabled_error_message', __( 'Media upload is disabled. Please Enable at least one media type to proceed.', 'buddypress-media' ) );
 
 		// localise media size config.
 		$media_size_config = array(
@@ -1543,7 +1543,7 @@ class RTMedia {
 		}
 		wp_localize_script( 'rtmedia-main', 'rtmedia_disable_media_in_commented_media', $rtmedia_disable_media );
 
-		wp_localize_script( 'rtmedia-main', 'rtmedia_disable_media_in_commented_media_text', esc_html__( 'Adding media in Comments is not allowed', 'buddypress-media' ) );
+		wp_localize_script( 'rtmedia-main', 'rtmedia_disable_media_in_commented_media_text', __( 'Adding media in Comments is not allowed', 'buddypress-media' ) );
 
 		wp_localize_script( 'rtmedia-backbone', 'rtmedia_exteansions', $rtmedia_extns );
 		wp_localize_script( 'rtmedia-backbone', 'rtMedia_update_plupload_comment', $params );

--- a/app/main/RTMediaUploadTerms.php
+++ b/app/main/RTMediaUploadTerms.php
@@ -82,7 +82,7 @@ if ( ! class_exists( 'RTMediaUploadTerms' ) && ! is_plugin_active( 'rtmedia-uplo
 					)
 				);
 
-				wp_localize_script( 'rtmedia-main', 'rtmedia_upload_terms_check_terms_message', esc_js( $general_upload_terms_error_message ) );
+				wp_localize_script( 'rtmedia-main', 'rtmedia_upload_terms_check_terms_message', $general_upload_terms_error_message );
 			}
 		}
 


### PR DESCRIPTION
Fixes half of #1573 
Next thing to do in 1573 is put all the localized data into an array so we can escape it without any problems.
This was not done currently because we need to make sure any of the localized data is not being used in any other addon or theme.