### PR TITLE
Fixed the error of radio buttons, not working after saving settings.

### DIFF
--- a/app/admin/RTMediaFormHandler.php
+++ b/app/admin/RTMediaFormHandler.php
@@ -170,7 +170,7 @@ class RTMediaFormHandler {
 		foreach ( $args['radios'] as $value => $key ) {
 			$args['rtForm_options'][] = array(
 				$key      => $value,
-				'checked' => ( strval( $args['default'] ) === strval( $value ) ) ? true : false, // strval is used to fix the privacy levels being integer to match the saved privacy value.
+				'checked' => ( strval( $args['default'] ) === strval( $value ) ) ? true : false, // The function 'strval()' is used to fix the privacy levels being integer to match the saved privacy value.
 			);
 		}
 

--- a/app/admin/RTMediaFormHandler.php
+++ b/app/admin/RTMediaFormHandler.php
@@ -170,7 +170,7 @@ class RTMediaFormHandler {
 		foreach ( $args['radios'] as $value => $key ) {
 			$args['rtForm_options'][] = array(
 				$key      => $value,
-				'checked' => ( (int) $args['default'] === $value ) ? true : false,
+				'checked' => ( $args['default'] == $value ) ? true : false, // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison The == error ignored as the privacy levels indexes are integer, and while saving in database, the saved value becomes string.
 			);
 		}
 

--- a/app/admin/RTMediaFormHandler.php
+++ b/app/admin/RTMediaFormHandler.php
@@ -170,7 +170,8 @@ class RTMediaFormHandler {
 		foreach ( $args['radios'] as $value => $key ) {
 			$args['rtForm_options'][] = array(
 				$key      => $value,
-				'checked' => ( strval( $args['default'] ) === strval( $value ) ) ? true : false, // The function 'strval()' is used to fix the privacy levels being integer to match the saved privacy value.
+				// The function 'strval()' is used to fix the privacy levels being integer to match the saved privacy value.
+				'checked' => ( strval( $args['default'] ) === strval( $value ) ) ? true : false,
 			);
 		}
 

--- a/app/admin/RTMediaFormHandler.php
+++ b/app/admin/RTMediaFormHandler.php
@@ -170,7 +170,7 @@ class RTMediaFormHandler {
 		foreach ( $args['radios'] as $value => $key ) {
 			$args['rtForm_options'][] = array(
 				$key      => $value,
-				'checked' => ( $args['default'] == $value ) ? true : false, // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- The == error ignored as the privacy levels indexes are integer, and while saving in database, the saved value becomes string.
+				'checked' => ( strval( $args['default'] ) === strval( $value ) ) ? true : false, // strval is used to fix the privacy levels being integer to match the saved privacy value.
 			);
 		}
 

--- a/app/admin/RTMediaFormHandler.php
+++ b/app/admin/RTMediaFormHandler.php
@@ -170,7 +170,7 @@ class RTMediaFormHandler {
 		foreach ( $args['radios'] as $value => $key ) {
 			$args['rtForm_options'][] = array(
 				$key      => $value,
-				'checked' => ( $args['default'] == $value ) ? true : false, // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison The == error ignored as the privacy levels indexes are integer, and while saving in database, the saved value becomes string.
+				'checked' => ( $args['default'] == $value ) ? true : false, // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- The == error ignored as the privacy levels indexes are integer, and while saving in database, the saved value becomes string.
 			);
 		}
 


### PR DESCRIPTION
This PR pertains to issue #1584 

This PR fixes the `checked` state of the radio buttons in plugin admin settings. The radio buttons after being checked were not showing as checked after saving settings.

Screenshots:
Privacy Settings: https://prnt.sc/rjj4c4
List Media View: https://prnt.sc/rjj4qc