### PR TITLE
Fix 1593: type casting bug

### DIFF
--- a/app/main/controllers/upload/RTMediaUploadEndpoint.php
+++ b/app/main/controllers/upload/RTMediaUploadEndpoint.php
@@ -296,7 +296,7 @@ class RTMediaUploadEndpoint {
 					}
 				}
 
-				if ( isset( $this->upload['rtmedia_simple_file_upload'] ) && true === $this->upload['rtmedia_simple_file_upload'] ) {
+				if ( isset( $this->upload['rtmedia_simple_file_upload'] ) && '1' === strval( $this->upload['rtmedia_simple_file_upload'] ) ) {
 
 					if ( isset( $media ) && count( $media ) > 0 ) {
 


### PR DESCRIPTION
This bug caused by PHPCS fixes.
Fix bug caused by strict checking `1` with `true`. Converted both to string and then applied strict check.
Fixes https://github.com/rtMediaWP/rtMedia/issues/1593