### PR TITLE
Add iframe in allowed html tags

### DIFF
--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1730,6 +1730,13 @@ class RTMedia {
 	public static function expanded_allowed_tags() {
 		$new_allowed = wp_kses_allowed_html( 'post' );
 
+		// Iframe.
+		$new_allowed['iframe'] = array(
+			'src'   => array(),
+			'class' => array(),
+			'id'    => array(),
+		);
+
 		// form input.
 		$new_allowed['form'] = array(
 			'action' => array(),


### PR DESCRIPTION
Add iframe in allowed html tags function `expanded_allowed_tags`
Fixes - https://github.com/rtMediaWP/rtMedia/issues/1615