### PR TITLE
Add custom stylings through wp_add_inline_style function

### DIFF
--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1555,6 +1555,15 @@ class RTMedia {
 		if ( empty( $is_buddypress_activate ) ) {
 			wp_localize_script( 'rtmedia-main', 'ajaxurl', admin_url( 'admin-ajax.php', is_ssl() ? 'admin' : 'http' ) );
 		}
+
+		$options = $rtmedia->options;
+		// Previously done with rtmedia_custom_css() method on wp_head hook.
+		if ( ! empty( $options['styles_custom'] ) ) {
+			wp_register_style( 'rtmedia-custom-css', false );
+			wp_enqueue_style( 'rtmedia-custom-css' );
+			$css = stripslashes( wp_filter_nohtml_kses( $options['styles_custom'] ) );
+			wp_add_inline_style( 'rtmedia-custom-css', $css );
+		}
 	}
 
 	/**

--- a/app/main/controllers/template/rtmedia-actions.php
+++ b/app/main/controllers/template/rtmedia-actions.php
@@ -395,6 +395,31 @@ function rtmedia_content_before_media() {
 add_action( 'rtmedia_before_media', 'rtmedia_content_before_media', 10 );
 
 /**
+ * Rendering custom CSS.
+ *
+ * @global RTMedia $rtmedia
+ *
+ * @return void
+ */
+function rtmedia_custom_css() {
+
+	global $rtmedia;
+
+	$options = $rtmedia->options;
+
+	if ( ! empty( $options['styles_custom'] ) ) {
+		?>
+		<style type='text/css'>
+			<?php stripslashes( wp_filter_nohtml_kses( $options['styles_custom'] ) ); ?>
+		</style>
+		<?php
+	}
+
+}
+
+add_action( 'wp_head', 'rtmedia_custom_css' );
+
+/**
  * Update the group media privacy according to the group privacy settings when group settings are changed
  *
  * @param int $group_id Buddypress Group id.

--- a/app/main/controllers/template/rtmedia-actions.php
+++ b/app/main/controllers/template/rtmedia-actions.php
@@ -395,31 +395,6 @@ function rtmedia_content_before_media() {
 add_action( 'rtmedia_before_media', 'rtmedia_content_before_media', 10 );
 
 /**
- * Rendering custom CSS.
- *
- * @global RTMedia $rtmedia
- *
- * @return void
- */
-function rtmedia_custom_css() {
-
-	global $rtmedia;
-
-	$options = $rtmedia->options;
-
-	if ( ! empty( $options['styles_custom'] ) ) {
-		?>
-		<style type='text/css'>
-			<?php stripslashes( wp_filter_nohtml_kses( $options['styles_custom'] ) ); ?>
-		</style>
-		<?php
-	}
-
-}
-
-add_action( 'wp_head', 'rtmedia_custom_css' );
-
-/**
  * Update the group media privacy according to the group privacy settings when group settings are changed
  *
  * @param int $group_id Buddypress Group id.


### PR DESCRIPTION
Add custom stylings through `wp_add_inline_style` function instead of directly printing, like it was being done in `rtmedia_custom_css` function.
Related commit - https://github.com/rtMediaWP/rtMedia/commit/ab30d0914b900cc8bc4b96dc13d84b6e2bdd79bf

https://github.com/rtMediaWP/rtMedia/commit/ab30d0914b900cc8bc4b96dc13d84b6e2bdd79bf#diff-f23e65e07ebeccfcd8de51efd0419621R1356-R1364 This code was removed after this commit, so I added it again.

Fixes https://github.com/rtMediaWP/rtMedia/issues/1609