### PR TITLE
Fix GH-1622: Remove wp_kses from comment html

### DIFF
--- a/app/main/controllers/template/RTMediaTemplate.php
+++ b/app/main/controllers/template/RTMediaTemplate.php
@@ -892,6 +892,7 @@ class RTMediaTemplate {
 					global $wpdb;
 
 					$comments = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->comments WHERE comment_ID = %d limit 100", $id ), ARRAY_A );
+					// @todo: Change a.rtmedia-comment-like-click attribute to data-comment-id from data-comment_id in rtmedia-likes (https://github.com/rtCamp/rtmedia-likes) addon.
 					echo rmedia_single_comment( $comments ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Contains data-* attributes.
 					exit;
 				}

--- a/app/main/controllers/template/RTMediaTemplate.php
+++ b/app/main/controllers/template/RTMediaTemplate.php
@@ -892,7 +892,7 @@ class RTMediaTemplate {
 					global $wpdb;
 
 					$comments = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->comments WHERE comment_ID = %d limit 100", $id ), ARRAY_A );
-					echo wp_kses( rmedia_single_comment( $comments ), RTMedia::expanded_allowed_tags() );
+					echo rmedia_single_comment( $comments ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Contains data-* attributes.
 					exit;
 				}
 			} else {

--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -1350,7 +1350,7 @@ function rtmedia_comments( $echo = true ) {
 	}
 
 	if ( $html ) {
-		echo wp_kses( $html, RTMedia::expanded_allowed_tags() );
+		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Contains data-* attributes.
 	} else {
 		return $html;
 	}

--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -1350,6 +1350,7 @@ function rtmedia_comments( $echo = true ) {
 	}
 
 	if ( $html ) {
+		// @todo: Change a.rtmedia-comment-like-click attribute to data-comment-id from data-comment_id in rtmedia-likes (https://github.com/rtCamp/rtmedia-likes) addon.
 		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Contains data-* attributes.
 	} else {
 		return $html;


### PR DESCRIPTION
Remove `wp_kses` from comment html as it contains `data-*` attributes.
Fixes - https://github.com/rtMediaWP/rtMedia/issues/1622