### PR TITLE
Fix GH-1633: Add script tag in allowed html for social sync addon

### DIFF
--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1748,10 +1748,10 @@ class RTMedia {
 
 		// Script, for social sync plugin.
 		$new_allowed['script'] = array(
-			'type'  => true,
-			'class' => true,
-			'id'    => true,
-			'src'   => true,
+			'type'  => array(),
+			'class' => array(),
+			'id'    => array(),
+			'src'   => array(),
 		);
 
 		// form input.

--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1746,6 +1746,14 @@ class RTMedia {
 			'id'    => array(),
 		);
 
+		// Script, for social sync plugin.
+		$new_allowed['script'] = array(
+			'type'  => true,
+			'class' => true,
+			'id'    => true,
+			'src'   => true,
+		);
+
 		// form input.
 		$new_allowed['form'] = array(
 			'action' => array(),


### PR DESCRIPTION
Add script tag in allowed HTML, because social sync addon uses it.
Fixes https://github.com/rtMediaWP/rtMedia/issues/1633