### PR TITLE
Fix GH-1635: Uses wpseo_frontend_presenters instead of deprectated wpseo_opengraph

### DIFF
--- a/app/main/interactions/RTMediaInteraction.php
+++ b/app/main/interactions/RTMediaInteraction.php
@@ -52,7 +52,7 @@ class RTMediaInteraction {
 
 		add_filter( 'wp_title', array( $this, 'set_title' ), 99999, 2 );
 		add_filter( 'wpseo_opengraph_title', array( $this, 'set_title' ), 9999, 1 );
-		add_filter( 'wpseo_opengraph', array( $this, 'rtmedia_wpseo_og_image' ), 999, 1 );
+		add_filter( 'wpseo_frontend_presenters', array( $this, 'rtmedia_wpseo_og_image' ), 999, 1 );
 		add_filter( 'wpseo_opengraph_url', array( $this, 'rtmedia_wpseo_og_url' ), 999, 1 );
 		add_filter( 'wpseo_opengraph_desc', array( $this, 'rtmedia_wpseo_og_desc' ), 999, 1 );
 	}


### PR DESCRIPTION
Used `wpseo_frontend_presenters` instead of deprectated `wpseo_opengraph`.
Filter `wpseo_opengraph` has been deprecated in Yoast SEO v14.0 and is throwing error because the filter isn't providing any value for callback but we're getting 1 value here.
Using `wpseo_frontend_presenters` instead fixes this error and adds `meta` tags under `head` on rtMedia's profile and group media pages as well.

Deprecation warning
> wpseo_opengraph is deprecated since version 14.0! Use wpseo_frontend_presenters instead

Fixes https://github.com/rtMediaWP/rtMedia/issues/1635