### PR TITLE
Fix GH-1636: Initialize $no as $diff / $length[ $i ] instead of 0

### DIFF
--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -3303,9 +3303,9 @@ function rtmedia_convert_date( $_date ) {
 	$length    = array( 1, 60, 3600, 86400 );
 	// translators: %s: count of hour/minute/second.
 	$ago_text = esc_html__( '%s ago ', 'buddypress-media' );
-	$no       = 0;
+	$no       = $diff / $length[ $i ];
 
-	for ( $i = count( $length ) - 1; ( $i >= 0 ) && ( $no <= 1 ); $i-- ) {
+	for ( $i = count( $length ) - 1; ( $i >= 0 && $no <= 1 ); $i -- ) {
 		$no = $diff / $length[ $i ];
 	}
 

--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -3303,9 +3303,11 @@ function rtmedia_convert_date( $_date ) {
 	$length    = array( 1, 60, 3600, 86400 );
 	// translators: %s: count of hour/minute/second.
 	$ago_text = esc_html__( '%s ago ', 'buddypress-media' );
-	$no       = $diff / $length[ $i ];
 
-	for ( $i = count( $length ) - 1; ( $i >= 0 && $no <= 1 ); $i -- ) {
+	$i  = count( $length ) - 1;
+	$no = $diff / $length[ $i ];
+	while ( $i >= 0 && $no <= 1 ) {
+		$i--;
 		$no = $diff / $length[ $i ];
 	}
 


### PR DESCRIPTION
Fix bug with for loop and used while loop instead.
```
for ( $i = sizeof( $length ) - 1; ( $i >= 0 ) && ( ( $no = $diff / $length[ $i ] ) <= 1 ); $i -- ) {}
```
This was the original code used in v4.6.0 where it was working, but it had PHPCS errors and couldn't write this in for loop manner.

Fixes https://github.com/rtMediaWP/rtMedia/issues/1636